### PR TITLE
refactor rename

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -49,7 +49,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback mutate(df, with_columns :: Keyword.t()) :: df
   @callback arrange(df, columns :: [colname], direction :: :asc | :desc) :: df
   @callback distinct(df, columns :: [colname], keep_all? :: boolean()) :: df
-  @callback rename(df, list(colname) | map() | function()) :: df
+  @callback rename(df, [colname]) :: df
   @callback dummies(df, columns :: [colname]) :: df
   @callback sample(df, integer() | float(), with_replacement? :: boolean()) :: df
   @callback pull(df, column :: String.t()) :: series

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -404,6 +404,8 @@ defmodule Explorer.DataFrame do
   @doc """
   Renames columns.
 
+  To apply a function to a subset of columns, see `rename_with/3`.
+
   ## Examples
 
     You can pass in a list of new names:
@@ -491,13 +493,91 @@ defmodule Explorer.DataFrame do
   defp rename_reducer({k, v}, acc) when is_binary(k) and is_atom(v),
     do: Map.put(acc, k, Atom.to_string(v))
 
+  @doc """
+  Renames columns with a function.
+
+  ## Examples
+
+    If no columns are specified, it will apply the function to all column names:
+
+      iex> df = Explorer.Datasets.fossil_fuels()
+      iex> Explorer.DataFrame.rename_with(df, &String.upcase/1)
       #Explorer.DataFrame<
-        [rows: 3, columns: 2]
-        first string ["a", "b", "a"]
-        b integer [1, 3, 1]
+        [rows: 1094, columns: 10]
+        YEAR integer [2010, 2010, 2010, 2010, 2010, "..."]
+        COUNTRY string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", "..."]
+        TOTAL integer [2308, 1254, 32500, 141, 7924, "..."]
+        SOLID_FUEL integer [627, 117, 332, 0, 0, "..."]
+        LIQUID_FUEL integer [1601, 953, 12381, 141, 3649, "..."]
+        GAS_FUEL integer [74, 7, 14565, 0, 374, "..."]
+        CEMENT integer [5, 177, 2598, 0, 204, "..."]
+        GAS_FLARING integer [0, 0, 2623, 0, 3697, "..."]
+        PER_CAPITA float [0.08, 0.43, 0.9, 1.68, 0.37, "..."]
+        BUNKER_FUELS integer [9, 7, 663, 0, 321, "..."]
+      >
+
+    A callback can be used to filter the column names that will be renamed, similarly to `select/3`:
+
+      iex> df = Explorer.Datasets.fossil_fuels()
+      iex> Explorer.DataFrame.rename_with(df, &String.trim_trailing(&1, "_fuel"), &String.ends_with?(&1, "_fuel"))
+      #Explorer.DataFrame<
+        [rows: 1094, columns: 10]
+        year integer [2010, 2010, 2010, 2010, 2010, "..."]
+        country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", "..."]
+        total integer [2308, 1254, 32500, 141, 7924, "..."]
+        solid integer [627, 117, 332, 0, 0, "..."]
+        liquid integer [1601, 953, 12381, 141, 3649, "..."]
+        gas integer [74, 7, 14565, 0, 374, "..."]
+        cement integer [5, 177, 2598, 0, 204, "..."]
+        gas_flaring integer [0, 0, 2623, 0, 3697, "..."]
+        per_capita float [0.08, 0.43, 0.9, 1.68, 0.37, "..."]
+        bunker_fuels integer [9, 7, 663, 0, 321, "..."]
+      >
+
+    Or you can just pass in the list of column names you'd like to apply the function to:
+
+      iex> df = Explorer.Datasets.fossil_fuels()
+      iex> Explorer.DataFrame.rename_with(df, &String.upcase/1, ["total", "cement"])
+      #Explorer.DataFrame<
+        [rows: 1094, columns: 10]
+        year integer [2010, 2010, 2010, 2010, 2010, "..."]
+        country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", "..."]
+        TOTAL integer [2308, 1254, 32500, 141, 7924, "..."]
+        solid_fuel integer [627, 117, 332, 0, 0, "..."]
+        liquid_fuel integer [1601, 953, 12381, 141, 3649, "..."]
+        gas_fuel integer [74, 7, 14565, 0, 374, "..."]
+        CEMENT integer [5, 177, 2598, 0, 204, "..."]
+        gas_flaring integer [0, 0, 2623, 0, 3697, "..."]
+        per_capita float [0.08, 0.43, 0.9, 1.68, 0.37, "..."]
+        bunker_fuels integer [9, 7, 663, 0, 321, "..."]
       >
   """
-  def rename(df, names), do: apply_impl(df, :rename, [names])
+  def rename_with(df, callback, columns \\ [])
+
+  def rename_with(df, callback, []) when is_function(callback),
+    do: df |> names() |> Enum.map(callback) |> then(&rename(df, &1))
+
+  def rename_with(df, callback, columns) when is_function(callback) and is_list(columns) do
+    old_names = names(df)
+
+    Enum.each(columns, fn name ->
+      maybe_raise_column_not_found(old_names, name)
+    end)
+
+    old_names
+    |> Enum.map(fn name -> if name in columns, do: callback.(name), else: name end)
+    |> then(&rename(df, &1))
+  end
+
+  def rename_with(df, callback, columns) when is_function(callback) and is_function(columns) do
+    case df |> names() |> Enum.filter(columns) do
+      [_ | _] = columns ->
+        rename_with(df, callback, columns)
+
+      [] ->
+        raise ArgumentError, message: "Function to select column names did not return any names."
+    end
+  end
 
   @doc """
   Turns a set of columns to dummy variables.
@@ -547,5 +627,39 @@ defmodule Explorer.DataFrame do
     left_cols = left |> names() |> MapSet.new()
     right_cols = right |> names() |> MapSet.new()
     left_cols |> MapSet.intersection(right_cols) |> MapSet.to_list()
+  end
+
+  defp maybe_raise_column_not_found(names, name) do
+    if name not in names,
+      do:
+        raise(ArgumentError,
+          message:
+            List.to_string(
+              ["Could not find column name \"#{name}\""] ++ did_you_mean(name, names)
+            )
+        )
+  end
+
+  @threshold 0.77
+  @max_suggestions 5
+  defp did_you_mean(missing_key, available_keys) do
+    suggestions =
+      for key <- available_keys,
+          distance = String.jaro_distance(missing_key, key),
+          distance >= @threshold,
+          do: {distance, key}
+
+    case suggestions do
+      [] -> []
+      suggestions -> [". Did you mean:\n\n" | format_suggestions(suggestions)]
+    end
+  end
+
+  defp format_suggestions(suggestions) do
+    suggestions
+    |> Enum.sort(&(elem(&1, 0) >= elem(&2, 0)))
+    |> Enum.take(@max_suggestions)
+    |> Enum.sort(&(elem(&1, 1) <= elem(&2, 1)))
+    |> Enum.map(fn {_, key} -> ["      * ", inspect(key), ?\n] end)
   end
 end

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -209,34 +209,8 @@ defmodule Explorer.PolarsBackend.DataFrame do
       |> select(columns, :keep)
 
   @impl true
-  def rename(df, names) when is_list(names) do
-    case Keyword.keyword?(names) do
-      false ->
-        Shared.apply_native(df, :df_set_column_names, [names])
-
-      true ->
-        new_names =
-          df
-          |> names()
-          |> Enum.reduce([], fn name, acc ->
-            name =
-              if Keyword.has_key?(names, String.to_atom(name)),
-                do:
-                  Keyword.get(
-                    names,
-                    String.to_atom(name)
-                  ),
-                else: name
-
-            [name | acc] |> Enum.reverse()
-          end)
-
-        rename(df, new_names)
-    end
-  end
-
-  def rename(df, fun) when is_function(fun),
-    do: rename(df, df |> names() |> Enum.map(fun))
+  def rename(df, names) when is_list(names),
+    do: Shared.apply_native(df, :df_set_column_names, [names])
 
   @impl true
   def dummies(df, names),


### PR DESCRIPTION
- Adds `Explorer.DataFrame.maybe_raise_column_not_found/2` to check if column names exist and suggest similar ones
- Refactors `Explorer.DataFrame.rename/2` to accommodate a simpler `Explorer.Backend.rename/2` callback
- Adds `Explorer.DataFrame.rename_with/2` for renaming columns with a function