### PR TITLE
add gh pages for docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,40 @@
 on: push
 
+env:
+  ELIXIR_VERSION: 1.12
+  OTP_VERSION: 24.0
+
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }} / OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
-        otp: ['24.0']
-        elixir: ['1.12.2']
+    runs-on: ubuntu-latest
+    name: test
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
-        name: Restore dependency cache
         with:
-          path: deps
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-mix-${{ hashFiles('**/mix.lock') }}
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-mix-
-      - name: Install latest Rust nightly
-        uses: actions-rs/toolchain@v1
+            ${{ runner.os }}-mix-
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            native/explorer/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions-rs/toolchain@v1
         with:
             toolchain: nightly
             override: true
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: ${{matrix.otp}}
-          elixir-version: ${{matrix.elixir}}
+          otp-version: "${{ env.OTP_VERSION }}"
+          elixir-version: "${{ env.ELIXIR_VERSION }}"
       - run: mix deps.get
       - run: mix compile --warnings-as-errors
       - run: mix test --warnings-as-errors 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,54 @@
+name: Docs on GitHub pages
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.ref }}-docs
+  cancel-in-progress: true
+
+env:
+  ELIXIR_VERSION: 1.12
+  OTP_VERSION: 24.0
+  MIX_ENV: test
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      MIX_ENV: test
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            native/explorer/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            override: true
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "${{ env.OTP_VERSION }}"
+          elixir-version: "${{ env.ELIXIR_VERSION }}"
+      - run: mix docs
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.1
+        with:
+          branch: gh-pages
+          folder: doc


### PR DESCRIPTION
Since I'm not going to publish to hex for a bit, this will publish docs to gh pages. Also simplifies the CI a bit for now and caches Rust deps and build outputs.