### PR TITLE
refactor select/3

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -210,12 +210,24 @@ defmodule Explorer.DataFrame do
 
   @doc """
   Returns the number of rows in the dataframe.
+
+  ## Examples
+
+      iex> df = Explorer.Datasets.fossil_fuels()
+      iex> Explorer.DataFrame.n_rows(df)
+      1094
   """
   @spec n_rows(df :: DataFrame.t()) :: integer()
   def n_rows(df), do: apply_impl(df, :n_rows)
 
   @doc """
   Returns the number of columns in the dataframe.
+
+  ## Examples
+
+      iex> df = Explorer.Datasets.fossil_fuels()
+      iex> Explorer.DataFrame.n_cols(df)
+      10
   """
   @spec n_cols(df :: DataFrame.t()) :: integer()
   def n_cols(df), do: apply_impl(df, :n_cols)
@@ -230,13 +242,49 @@ defmodule Explorer.DataFrame do
 
   @doc """
   Returns the first *n* rows of the dataframe.
+
+  ## Examples
+
+      iex> df = Explorer.Datasets.fossil_fuels()
+      iex> Explorer.DataFrame.head(df)
+      #Explorer.DataFrame<
+        [rows: 5, columns: 10]
+        year integer [2010, 2010, 2010, 2010, 2010]
+        country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA"]
+        total integer [2308, 1254, 32500, 141, 7924]
+        solid_fuel integer [627, 117, 332, 0, 0]
+        liquid_fuel integer [1601, 953, 12381, 141, 3649]
+        gas_fuel integer [74, 7, 14565, 0, 374]
+        cement integer [5, 177, 2598, 0, 204]
+        gas_flaring integer [0, 0, 2623, 0, 3697]
+        per_capita float [0.08, 0.43, 0.9, 1.68, 0.37]
+        bunker_fuels integer [9, 7, 663, 0, 321]
+      >
   """
-  def head(df, nrows \\ 6), do: apply_impl(df, :head, [nrows])
+  def head(df, nrows \\ 5), do: apply_impl(df, :head, [nrows])
 
   @doc """
   Returns the last *n* rows of the dataframe.
+
+  ## Examples
+
+      iex> df = Explorer.Datasets.fossil_fuels()
+      iex> Explorer.DataFrame.tail(df)
+      #Explorer.DataFrame<
+        [rows: 5, columns: 10]
+        year integer [2014, 2014, 2014, 2014, 2014]
+        country string ["VIET NAM", "WALLIS AND FUTUNA ISLANDS", "YEMEN", "ZAMBIA", "ZIMBABWE"]
+        total integer [45517, 6, 6190, 1228, 3278]
+        solid_fuel integer [19246, 0, 137, 132, 2097]
+        liquid_fuel integer [12694, 6, 5090, 797, 1005]
+        gas_fuel integer [5349, 0, 581, 0, 0]
+        cement integer [8229, 0, 381, 299, 177]
+        gas_flaring integer [0, 0, 0, 0, 0]
+        per_capita float [0.49, 0.44, 0.24, 0.08, 0.22]
+        bunker_fuels integer [761, 1, 153, 33, 9]
+      >
   """
-  def tail(df, nrows \\ 6), do: apply_impl(df, :tail, [nrows])
+  def tail(df, nrows \\ 5), do: apply_impl(df, :tail, [nrows])
 
   @doc """
   Selects a subset of columns by name.
@@ -309,7 +357,7 @@ defmodule Explorer.DataFrame do
   def filter(df, mask), do: apply_impl(df, :filter, [mask])
 
   @doc """
-  Creates an modifies columns.
+  Creates and modifies columns.
 
   Columns are added as keyword list arguments. New variables overwrite existing variables of the 
   same name. Column names are coerced from atoms to strings.

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -135,22 +135,15 @@ defmodule Explorer.PolarsBackend.DataFrame do
   def tail(df, rows), do: Shared.apply_native(df, :df_tail, [rows])
 
   @impl true
-  def select(df, colnames, keep_or_drop) when is_list(colnames) do
+  def select(df, columns, keep_or_drop) when is_list(columns) do
     func =
       case keep_or_drop do
         :keep -> &Native.df_select/2
         :drop -> &drop/2
       end
 
-    df |> Shared.to_polars_df() |> func.(colnames) |> Shared.unwrap()
+    df |> Shared.to_polars_df() |> func.(columns) |> Shared.unwrap()
   end
-
-  def select(df, callback, keep_or_drop) when is_function(callback),
-    do:
-      df
-      |> names()
-      |> Enum.filter(callback)
-      |> then(&select(df, &1, keep_or_drop))
 
   defp drop(polars_df, colnames),
     do: Enum.reduce(colnames, polars_df, fn name, df -> Native.df_drop(df, name) end)


### PR DESCRIPTION
Improves `Explorer.DataFrame.select/3` by simplifying the backend and handling argument errors before they raise in Polars. Adds some additional documentation.