### PR TITLE
refactor mutate

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -46,7 +46,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback tail(df, rows :: integer()) :: df
   @callback select(df, columns :: [colname], :keep | :drop) :: df
   @callback filter(df, mask :: series) :: df
-  @callback mutate(df, with_columns :: Keyword.t()) :: df
+  @callback mutate(df, with_columns :: map()) :: df
   @callback arrange(df, columns :: [colname], direction :: :asc | :desc) :: df
   @callback distinct(df, columns :: [colname], keep_all? :: boolean()) :: df
   @callback rename(df, [colname]) :: df

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -162,21 +162,6 @@ defmodule Explorer.PolarsBackend.DataFrame do
     Shared.apply_native(df, :df_with_column, [series])
   end
 
-  defp mutate_reducer({colname, arg}, %DataFrame{} = df) when is_atom(colname),
-    do: mutate_reducer({Atom.to_string(colname), arg}, df)
-
-  defp mutate_reducer({colname, callback}, df) when is_function(callback) do
-    series = callback.(df)
-    mutate_reducer({colname, series}, df)
-  end
-
-  defp mutate_reducer({colname, values}, %DataFrame{} = df) when is_list(values) do
-    series = Series.from_list(values)
-    mutate_reducer({colname, series}, df)
-  end
-
-  defp mutate_reducer({_colname, _values}, error), do: {:error, error}
-
   @impl true
   def arrange(df, columns, direction \\ :asc),
     do:

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1,4 +1,26 @@
 defmodule Explorer.DataFrameTest do
   use ExUnit.Case, async: true
   doctest Explorer.DataFrame
+
+  alias Explorer.DataFrame, as: DF
+
+  setup do
+    {:ok, df: Explorer.Datasets.fossil_fuels()}
+  end
+
+  describe "filter/2" do
+    test "raises with mask of invalid length", %{df: df} do
+      assert_raise ArgumentError,
+                   "Length of the mask (3) must match number of rows in the dataframe (1094).",
+                   fn -> DF.filter(df, [true, false, true]) end
+    end
+  end
+
+  describe "mutate/2" do
+    test "raises with series of invalid length", %{df: df} do
+      assert_raise ArgumentError,
+                   "Length of new column test (3) must match number of rows in the dataframe (1094).",
+                   fn -> DF.mutate(df, test: [1, 2, 3]) end
+    end
+  end
 end


### PR DESCRIPTION
Tidies up mutate and follows #11 and #10 in pulling logic from the backend to the surface and adding checks on arguments. Adds a couple tests for raising `ArgumentError`.