### PR TITLE
refactor arrange

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -47,7 +47,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback select(df, columns :: [colname], :keep | :drop) :: df
   @callback filter(df, mask :: series) :: df
   @callback mutate(df, with_columns :: map()) :: df
-  @callback arrange(df, columns :: [colname], direction :: :asc | :desc) :: df
+  @callback arrange(df, columns :: [colname | {colname, :asc | :desc}]) :: df
   @callback distinct(df, columns :: [colname], keep_all? :: boolean()) :: df
   @callback rename(df, [colname]) :: df
   @callback dummies(df, columns :: [colname]) :: df

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -163,9 +163,9 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def arrange(df, columns, direction \\ :asc),
+  def arrange(df, columns),
     do:
-      Enum.reduce(columns, df, fn column, df ->
+      Enum.reduce(columns, df, fn {column, direction}, df ->
         Shared.apply_native(df, :df_sort, [column, direction == :desc])
       end)
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -23,4 +23,12 @@ defmodule Explorer.DataFrameTest do
                    fn -> DF.mutate(df, test: [1, 2, 3]) end
     end
   end
+
+  describe "arrange/3" do
+    test "raises with invalid column names", %{df: df} do
+      assert_raise ArgumentError,
+                   "Could not find column name \"test\"",
+                   fn -> DF.arrange(df, ["test"]) end
+    end
+  end
 end


### PR DESCRIPTION
Changes `DataFrame.arrange/3` to `DataFrame.arrange/2`, allowing each column to have its own direction.