### PR TITLE
refactor join

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -61,7 +61,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback join(
               left :: df,
               right :: df,
-              how :: :left | :inner | :outer | :right,
+              how :: :left | :inner | :outer | :right | :cross,
               on ::
                 list(String.t())
             ) :: df

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -902,7 +902,59 @@ defmodule Explorer.DataFrame do
   @doc """
   Subset a continuous set of rows.
 
-  Negative offset will be counted from the end of the dataframe.
+  ## Examples
+
+      iex> df = Explorer.Datasets.fossil_fuels()
+      iex> Explorer.DataFrame.slice(df, 1, 2) 
+      #Explorer.DataFrame<
+        [rows: 2, columns: 10]
+        year integer [2010, 2010]
+        country string ["ALBANIA", "ALGERIA"]
+        total integer [1254, 32500]
+        solid_fuel integer [117, 332]
+        liquid_fuel integer [953, 12381]
+        gas_fuel integer [7, 14565]
+        cement integer [177, 2598]
+        gas_flaring integer [0, 2623]
+        per_capita float [0.43, 0.9]
+        bunker_fuels integer [7, 663]
+      >
+
+    Negative offsets count from the end of the series:
+
+      iex> df = Explorer.Datasets.fossil_fuels()
+      iex> Explorer.DataFrame.slice(df, -10, 2) 
+      #Explorer.DataFrame<
+        [rows: 2, columns: 10]
+        year integer [2014, 2014]
+        country string ["UNITED STATES OF AMERICA", "URUGUAY"]
+        total integer [1432855, 1840]
+        solid_fuel integer [450047, 2]
+        liquid_fuel integer [576531, 1700]
+        gas_fuel integer [390719, 25]
+        cement integer [11314, 112]
+        gas_flaring integer [4244, 0]
+        per_capita float [4.43, 0.54]
+        bunker_fuels integer [30722, 251]
+      >
+
+    If the length would run past the end of the dataframe, the result may be shorter than the length:
+
+      iex> df = Explorer.Datasets.fossil_fuels()
+      iex> Explorer.DataFrame.slice(df, -10, 20) 
+      #Explorer.DataFrame<
+        [rows: 10, columns: 10]
+        year integer [2014, 2014, 2014, 2014, 2014, "..."]
+        country string ["UNITED STATES OF AMERICA", "URUGUAY", "UZBEKISTAN", "VANUATU", "VENEZUELA", "..."]
+        total integer [1432855, 1840, 28692, 42, 50510, "..."]
+        solid_fuel integer [450047, 2, 1677, 0, 204, "..."]
+        liquid_fuel integer [576531, 1700, 2086, 42, 28445, "..."]
+        gas_fuel integer [390719, 25, 23929, 0, 12731, "..."]
+        cement integer [11314, 112, 1000, 0, 1088, "..."]
+        gas_flaring integer [4244, 0, 0, 0, 8042, "..."]
+        per_capita float [4.43, 0.54, 0.97, 0.16, 1.65, "..."]
+        bunker_fuels integer [30722, 251, 0, 10, 1256, "..."]
+      >
   """
   def slice(df, offset, length), do: apply_impl(df, :slice, [offset, length])
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -960,8 +960,31 @@ defmodule Explorer.DataFrame do
 
   @doc """
   Subset rows with a list of indices.
+
+  ## Examples
+
+      iex> df = Explorer.DataFrame.from_map(%{a: [1, 2, 3], b: ["a", "b", "c"]})
+      iex> Explorer.DataFrame.take(df, [0, 2])
+      #Explorer.DataFrame<
+        [rows: 2, columns: 2]
+        a integer [1, 3]
+        b string ["a", "c"]
+      >
   """
-  def take(df, row_indices), do: apply_impl(df, :take, [row_indices])
+  def take(df, row_indices) when is_list(row_indices) do
+    n_rows = n_rows(df)
+
+    Enum.each(row_indices, fn idx ->
+      if idx > n_rows or idx < -n_rows,
+        do:
+          raise(
+            ArgumentError,
+            "Requested row index (#{idx}) out of bounds (-#{n_rows}:#{n_rows})."
+          )
+    end)
+
+    apply_impl(df, :take, [row_indices])
+  end
 
   # Two table verbs
 

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -209,13 +209,13 @@ defmodule Explorer.PolarsBackend.DataFrame do
   # Two table verbs
 
   @impl true
-  def join(left, right, how, :right), do: join(right, left, how, :left)
+  def join(left, right, on, :right), do: join(right, left, on, :left)
 
-  def join(left, right, how, on) do
+  def join(left, right, on, how) do
     how = Atom.to_string(how)
     {left_on, right_on} = Enum.reduce(on, {[], []}, &join_on_reducer/2)
 
-    Native.df_join(left, right, left_on, right_on, how)
+    Shared.apply_native(left, :df_join, [Shared.to_polars_df(right), left_on, right_on, how])
   end
 
   defp join_on_reducer(colname, {left, right}) when is_binary(colname),

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -20,6 +20,7 @@ git = "https://github.com/ritchie46/polars"
 rev = "451ab7baea22955284eb407bb9c9281f79935ab3"
 default-features = false
 features = [
+  "cross_join",
   "dtype-date32",
   "dtype-date64",
   "is_in",

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -170,6 +170,7 @@ pub fn df_join(
         "left" => JoinType::Left,
         "inner" => JoinType::Inner,
         "outer" => JoinType::Outer,
+        "cross" => JoinType::Cross,
         _ => return Err(ExplorerError::Other(format!("Join method {} not supported", how)).into()),
     };
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -31,4 +31,12 @@ defmodule Explorer.DataFrameTest do
                    fn -> DF.arrange(df, ["test"]) end
     end
   end
+
+  describe "take/2" do
+    test "raises with index out of bounds", %{df: df} do
+      assert_raise ArgumentError,
+                   "Requested row index (2000) out of bounds (-1094:1094).",
+                   fn -> DF.take(df, [1, 2, 3, 2000]) end
+    end
+  end
 end

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -39,4 +39,23 @@ defmodule Explorer.DataFrameTest do
                    fn -> DF.take(df, [1, 2, 3, 2000]) end
     end
   end
+
+  describe "join/3" do
+    test "raises if no overlapping columns" do
+      assert_raise ArgumentError,
+                   "Could not find any overlapping columns.",
+                   fn ->
+                     left = DF.from_map(%{a: [1, 2, 3]})
+                     right = DF.from_map(%{b: [1, 2, 3]})
+                     DF.join(left, right)
+                   end
+    end
+
+    test "doesn't raise if no overlapping columns on cross join" do
+      left = DF.from_map(%{a: [1, 2, 3]})
+      right = DF.from_map(%{b: [1, 2, 3]})
+      joined = DF.join(left, right, how: :cross)
+      assert %DF{} = joined
+    end
+  end
 end

--- a/test/explorer_test.exs
+++ b/test/explorer_test.exs
@@ -1,4 +1,4 @@
 defmodule Explorer.ExplorerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest Explorer
 end


### PR DESCRIPTION
Corrects the `DataFrame.join/3` implementation and adds cross join. Adds documentation and tests.