### PR TITLE
add groupby and summarise

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -66,4 +66,9 @@ defmodule Explorer.Backend.DataFrame do
               on ::
                 list(String.t())
             ) :: df
+
+  # Groups
+
+  @callback group_by(df, columns :: [colname]) :: df
+  @callback ungroup(df, columns :: [colname]) :: df
 end

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -71,4 +71,5 @@ defmodule Explorer.Backend.DataFrame do
 
   @callback group_by(df, columns :: [colname]) :: df
   @callback ungroup(df, columns :: [colname]) :: df
+  @callback summarise(df, aggregations :: map()) :: df
 end

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -55,6 +55,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback pull(df, column :: String.t()) :: series
   @callback slice(df, offset :: integer(), length :: integer()) :: df
   @callback take(df, indices :: list(integer())) :: df
+  @callback drop_nil(df, columns :: [colname]) :: df
 
   # Two table verbs
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -688,10 +688,40 @@ defmodule Explorer.DataFrame do
   end
 
   @spec distinct(df :: DataFrame.t(), callback :: function(), keep_all? :: boolean()) ::
+  @doc """
+  Drop nil values.
+
+  Optionally accepts a subset of columns.
+
+  ## Examples
+
+      iex> df = Explorer.DataFrame.from_map(%{a: [1, 2, nil], b: [1, nil, 3]})
+      iex> Explorer.DataFrame.drop_nil(df)
+      #Explorer.DataFrame<
+        [rows: 1, columns: 2]
+        a integer [1]
+        b integer [1]
+      >
+  """
+  @spec drop_nil(df :: DataFrame.t(), columns_or_column :: [String.t()] | String.t()) ::
           DataFrame.t()
   def distinct(df, callback, keep_all?) when is_function(callback) do
     columns = df |> names() |> Enum.filter(callback)
     distinct(df, columns, keep_all?)
+  def drop_nil(df, columns_or_column \\ [])
+
+  def drop_nil(df, []), do: drop_nil(df, names(df))
+
+  def drop_nil(df, column) when is_binary(column), do: drop_nil(df, [column])
+
+  def drop_nil(df, columns) when is_list(columns) do
+    column_names = names(df)
+
+    Enum.each(columns, fn name ->
+      maybe_raise_column_not_found(column_names, name)
+    end)
+
+    apply_impl(df, :drop_nil, [columns])
   end
 
   @doc """

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -293,7 +293,7 @@ defmodule Explorer.DataFrame do
         bunker_fuels integer [761, 1, 153, 33, 9]
       >
   """
-  @spec head(df :: DataFrame.t(), nrows :: integer()) :: DataFrame.t()
+  @spec tail(df :: DataFrame.t(), nrows :: integer()) :: DataFrame.t()
   def tail(df, nrows \\ 5), do: apply_impl(df, :tail, [nrows])
 
   @doc """

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -152,7 +152,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
         :drop -> &drop/2
       end
 
-    df |> Shared.to_polars_df() |> func.(columns) |> Shared.unwrap()
+    df |> Shared.to_polars_df() |> func.(columns) |> Shared.unwrap(df.groups)
   end
 
   defp drop(polars_df, colnames),

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -207,6 +207,9 @@ defmodule Explorer.PolarsBackend.DataFrame do
   @impl true
   def take(df, row_indices), do: Shared.apply_native(df, :df_take, [row_indices])
 
+  @impl true
+  def drop_nil(df, columns), do: Shared.apply_native(df, :df_drop_nulls, [columns])
+
   # Two table verbs
 
   @impl true

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -297,6 +297,13 @@ defmodule Explorer.PolarsBackend.DataFrame do
   def ungroup(df, groups),
     do: %DataFrame{df | groups: Enum.filter(df.groups, &(&1 not in groups))}
 
+  @impl true
+  def summarise(%DataFrame{groups: groups} = df, with_columns) do
+    with_columns =
+      Enum.map(with_columns, fn {key, values} -> {key, Enum.map(values, &Atom.to_string/1)} end)
+
+    df |> Shared.apply_native(:df_groupby_agg, [groups, with_columns]) |> ungroup([])
+  end
 end
 
 defimpl Enumerable, for: Explorer.PolarsBackend.DataFrame do

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -252,6 +252,19 @@ defmodule Explorer.PolarsBackend.DataFrame do
 
   defp join_on_reducer({new_left, new_right}, {left, right}),
     do: {[new_left | left], [new_right | right]}
+
+  # Groups
+
+  @impl true
+  def group_by(%DataFrame{groups: groups} = df, new_groups),
+    do: %DataFrame{df | groups: groups ++ new_groups}
+
+  @impl true
+  def ungroup(df, []), do: %DataFrame{df | groups: []}
+
+  def ungroup(df, groups),
+    do: %DataFrame{df | groups: Enum.filter(df.groups, &(&1 not in groups))}
+
 end
 
 defimpl Enumerable, for: Explorer.PolarsBackend.DataFrame do

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -314,7 +314,10 @@ defmodule Explorer.PolarsBackend.DataFrame do
     with_columns =
       Enum.map(with_columns, fn {key, values} -> {key, Enum.map(values, &Atom.to_string/1)} end)
 
-    df |> Shared.apply_native(:df_groupby_agg, [groups, with_columns]) |> ungroup([])
+    df
+    |> Shared.apply_native(:df_groupby_agg, [groups, with_columns])
+    |> ungroup([])
+    |> DataFrame.arrange(groups)
   end
 end
 

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -77,6 +77,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_take_with_series(_df, _indices), do: err()
   def df_to_dummies(_df), do: err()
   def df_var(_df), do: err()
+  def df_vstack(_df, _other), do: err()
   def df_width(_df), do: err()
   def df_with_column(_df, _col), do: err()
 

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -47,6 +47,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_frame_equal(_df, _other, _null_equal), do: err()
   def df_get_columns(_df), do: err()
   def df_groups(_df, _colnames), do: err()
+  def df_groupby_agg(_df, _groups, _aggs), do: err()
   def df_head(_df, _length), do: err()
   def df_height(_df), do: err()
   def df_hstack(_df, _cols), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -46,6 +46,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_find_idx_by_name(_df, _name), do: err()
   def df_frame_equal(_df, _other, _null_equal), do: err()
   def df_get_columns(_df), do: err()
+  def df_groups(_df, _colnames), do: err()
   def df_head(_df, _length), do: err()
   def df_height(_df), do: err()
   def df_hstack(_df, _cols), do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -110,19 +110,16 @@ defmodule Explorer.PolarsBackend.Series do
     do: Shared.apply_native(series, :s_take, [indices])
 
   @impl true
-  def get(%Series{dtype: :date} = series, idx),
-    do:
-      series
-      |> Shared.apply_native(:s_get, [idx])
-      |> decode_date()
+  def get(%Series{dtype: dtype} = series, idx) do
+    idx = if idx < 0, do: length(series) + idx, else: idx
+    value = Shared.apply_native(series, :s_get, [idx])
 
-  def get(%Series{dtype: :datetime} = series, idx),
-    do:
-      series
-      |> Shared.apply_native(:s_get, [idx])
-      |> decode_datetime()
-
-  def get(series, idx), do: Shared.apply_native(series, :s_get, [idx])
+    case dtype do
+      :date -> decode_date(value)
+      :datetime -> decode_datetime(value)
+      _ -> value
+    end
+  end
 
   # Aggregation
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -399,7 +399,15 @@ defmodule Explorer.Series do
       "c"
   """
   @spec get(series :: Series.t(), idx :: integer()) :: any()
-  def get(series, idx), do: apply_impl(series, :get, [idx])
+  def get(series, idx) do
+    s_len = length(series)
+
+    if idx > s_len - 1 || idx < -s_len,
+      do:
+        raise(ArgumentError, message: "Index #{idx} out of bounds for series of length #{s_len}")
+
+    apply_impl(series, :get, [idx])
+  end
 
   # Aggregation
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -271,6 +271,11 @@ defmodule Explorer.Series do
   def first(series), do: series[0]
 
   @doc """
+  Returns the last element of the series.
+  """
+  def last(series), do: series[-1]
+
+  @doc """
   Returns a random sample of the series.
 
   If given an integer as the second argument, it will return N samples. If given a float, it will

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -916,6 +916,22 @@ defmodule Explorer.Series do
   def eq(%Series{dtype: dtype} = left, %Series{dtype: dtype} = right),
     do: apply_impl(left, :eq, [right])
 
+  def eq(%Series{dtype: dtype} = left, right)
+      when dtype in [:integer, :float] and is_number(right),
+      do: apply_impl(left, :eq, [right])
+
+  def eq(%Series{dtype: :date} = left, %Date{} = right),
+    do: apply_impl(left, :eq, [right])
+
+  def eq(%Series{dtype: :datetime} = left, %NaiveDateTime{} = right),
+    do: apply_impl(left, :eq, [right])
+
+  def eq(%Series{dtype: :string} = left, right) when is_binary(right),
+    do: apply_impl(left, :eq, [right])
+
+  def eq(%Series{dtype: :boolean} = left, right) when is_boolean(right),
+    do: apply_impl(left, :eq, [right])
+
   @doc """
   Returns boolean mask of `left != right`, element-wise.
 
@@ -934,6 +950,22 @@ defmodule Explorer.Series do
           right :: Series.t() | number() | Date.t() | NaiveDateTime.t() | boolean() | String.t()
         ) :: Series.t()
   def neq(%Series{dtype: dtype} = left, %Series{dtype: dtype} = right),
+    do: apply_impl(left, :neq, [right])
+
+  def neq(%Series{dtype: dtype} = left, right)
+      when dtype in [:integer, :float] and is_number(right),
+      do: apply_impl(left, :neq, [right])
+
+  def neq(%Series{dtype: :date} = left, %Date{} = right),
+    do: apply_impl(left, :neq, [right])
+
+  def neq(%Series{dtype: :datetime} = left, %NaiveDateTime{} = right),
+    do: apply_impl(left, :neq, [right])
+
+  def neq(%Series{dtype: :string} = left, right) when is_binary(right),
+    do: apply_impl(left, :neq, [right])
+
+  def neq(%Series{dtype: :boolean} = left, right) when is_boolean(right),
     do: apply_impl(left, :neq, [right])
 
   @doc """

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -266,6 +266,11 @@ defmodule Explorer.Series do
   def tail(series, n_elements \\ 10), do: apply_impl(series, :tail, [n_elements])
 
   @doc """
+  Returns the first element of the series.
+  """
+  def first(series), do: series[0]
+
+  @doc """
   Returns a random sample of the series.
 
   If given an integer as the second argument, it will return N samples. If given a float, it will

--- a/native/explorer/Cargo.lock
+++ b/native/explorer/Cargo.lock
@@ -757,7 +757,7 @@ dependencies = [
 [[package]]
 name = "polars"
 version = "0.14.8"
-source = "git+https://github.com/ritchie46/polars?rev=451ab7baea22955284eb407bb9c9281f79935ab3#451ab7baea22955284eb407bb9c9281f79935ab3"
+source = "git+https://github.com/ritchie46/polars?rev=4af944380df6ae4408f0e77316e18ae3e3ae6a0c#4af944380df6ae4408f0e77316e18ae3e3ae6a0c"
 dependencies = [
  "polars-core",
  "polars-io",
@@ -767,7 +767,7 @@ dependencies = [
 [[package]]
 name = "polars-arrow"
 version = "0.14.8"
-source = "git+https://github.com/ritchie46/polars?rev=451ab7baea22955284eb407bb9c9281f79935ab3#451ab7baea22955284eb407bb9c9281f79935ab3"
+source = "git+https://github.com/ritchie46/polars?rev=4af944380df6ae4408f0e77316e18ae3e3ae6a0c#4af944380df6ae4408f0e77316e18ae3e3ae6a0c"
 dependencies = [
  "arrow",
  "num",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "polars-core"
 version = "0.14.8"
-source = "git+https://github.com/ritchie46/polars?rev=451ab7baea22955284eb407bb9c9281f79935ab3#451ab7baea22955284eb407bb9c9281f79935ab3"
+source = "git+https://github.com/ritchie46/polars?rev=4af944380df6ae4408f0e77316e18ae3e3ae6a0c#4af944380df6ae4408f0e77316e18ae3e3ae6a0c"
 dependencies = [
  "ahash",
  "anyhow",
@@ -802,7 +802,7 @@ dependencies = [
 [[package]]
 name = "polars-io"
 version = "0.14.8"
-source = "git+https://github.com/ritchie46/polars?rev=451ab7baea22955284eb407bb9c9281f79935ab3#451ab7baea22955284eb407bb9c9281f79935ab3"
+source = "git+https://github.com/ritchie46/polars?rev=4af944380df6ae4408f0e77316e18ae3e3ae6a0c#4af944380df6ae4408f0e77316e18ae3e3ae6a0c"
 dependencies = [
  "ahash",
  "anyhow",
@@ -826,7 +826,7 @@ dependencies = [
 [[package]]
 name = "polars-lazy"
 version = "0.14.8"
-source = "git+https://github.com/ritchie46/polars?rev=451ab7baea22955284eb407bb9c9281f79935ab3#451ab7baea22955284eb407bb9c9281f79935ab3"
+source = "git+https://github.com/ritchie46/polars?rev=4af944380df6ae4408f0e77316e18ae3e3ae6a0c#4af944380df6ae4408f0e77316e18ae3e3ae6a0c"
 dependencies = [
  "ahash",
  "itertools",

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -19,7 +19,7 @@ rand_pcg = "0.3.1"
 
 [dependencies.polars]
 git = "https://github.com/ritchie46/polars"
-rev = "451ab7baea22955284eb407bb9c9281f79935ab3"
+rev = "4af944380df6ae4408f0e77316e18ae3e3ae6a0c"
 default-features = false
 features = [
   "cross_join",

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -209,6 +209,13 @@ pub fn df_hstack(data: ExDataFrame, cols: Vec<ExSeries>) -> Result<ExDataFrame, 
 }
 
 #[rustler::nif]
+pub fn df_vstack(data: ExDataFrame, other: ExDataFrame) -> Result<ExDataFrame, ExplorerError> {
+    df_read_read!(data, other, df, df1, {
+        Ok(ExDataFrame::new(df.vstack(&df1.clone())?))
+    })
+}
+
+#[rustler::nif]
 pub fn df_drop_nulls(
     data: ExDataFrame,
     subset: Option<Vec<String>>,

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -119,30 +119,6 @@ pub fn df_as_str(data: ExDataFrame) -> Result<String, ExplorerError> {
 }
 
 #[rustler::nif]
-pub fn df_sample_n(
-    data: ExDataFrame,
-    n: usize,
-    with_replacement: bool,
-) -> Result<ExDataFrame, ExplorerError> {
-    df_read!(data, df, {
-        let new_df = df.sample_n(n, with_replacement)?;
-        Ok(ExDataFrame::new(new_df))
-    })
-}
-
-#[rustler::nif]
-pub fn df_sample_frac(
-    data: ExDataFrame,
-    frac: f64,
-    with_replacement: bool,
-) -> Result<ExDataFrame, ExplorerError> {
-    df_read!(data, df, {
-        let new_df = df.sample_frac(frac, with_replacement)?;
-        Ok(ExDataFrame::new(new_df))
-    })
-}
-
-#[rustler::nif]
 pub fn df_fill_none(data: ExDataFrame, strategy: &str) -> Result<ExDataFrame, ExplorerError> {
     let strat = match strategy {
         "backward" => FillNoneStrategy::Backward,

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -419,10 +419,10 @@ pub fn df_shift(data: ExDataFrame, periods: i64) -> Result<ExDataFrame, Explorer
 pub fn df_drop_duplicates(
     data: ExDataFrame,
     maintain_order: bool,
-    subset: Option<Vec<String>>,
+    subset: Vec<String>,
 ) -> Result<ExDataFrame, ExplorerError> {
     df_read!(data, df, {
-        let new_df = df.drop_duplicates(maintain_order, subset.as_ref().map(|v| v.as_ref()))?;
+        let new_df = df.drop_duplicates(maintain_order, Some(&subset))?;
         Ok(ExDataFrame::new(new_df))
     })
 }
@@ -518,5 +518,13 @@ pub fn df_cast(
             .may_apply(column, |s: &Series| cast(s, to_type))?
             .clone();
         Ok(ExDataFrame::new(new_df))
+    })
+}
+
+#[rustler::nif]
+pub fn df_groups(data: ExDataFrame, groups: Vec<&str>) -> Result<ExDataFrame, ExplorerError> {
+    df_read!(data, df, {
+        let groups = df.groupby(groups)?.groups()?;
+        Ok(ExDataFrame::new(groups))
     })
 }

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -528,3 +528,15 @@ pub fn df_groups(data: ExDataFrame, groups: Vec<&str>) -> Result<ExDataFrame, Ex
         Ok(ExDataFrame::new(groups))
     })
 }
+
+#[rustler::nif]
+pub fn df_groupby_agg(
+    data: ExDataFrame,
+    groups: Vec<&str>,
+    aggs: Vec<(&str, Vec<&str>)>,
+) -> Result<ExDataFrame, ExplorerError> {
+    df_read!(data, df, {
+        let new_df = df.groupby(groups)?.agg(&aggs)?;
+        Ok(ExDataFrame::new(new_df))
+    })
+}

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -39,6 +39,7 @@ rustler::init!(
         df_frame_equal,
         df_get_columns,
         df_groups,
+        df_groupby_agg,
         df_head,
         df_height,
         df_hstack,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -70,6 +70,7 @@ rustler::init!(
         df_to_csv_file,
         df_to_dummies,
         df_var,
+        df_vstack,
         df_width,
         df_with_column,
         // series

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -38,6 +38,7 @@ rustler::init!(
         df_find_idx_by_name,
         df_frame_equal,
         df_get_columns,
+        df_groups,
         df_head,
         df_height,
         df_hstack,


### PR DESCRIPTION
Closes #2 

The API for summarise is more limited than I'd like for now, as I'm leaning on the built-in Polars behaviour for groupby/agg. I've made arrange, distinct, n_rows, and mutate 'group-aware' in a naive way which will certainly have some performance problems. But it gets the job done for now.

There are a good few other bits in here. I've bumped the polars version as there was an error with `drop_duplicates` with string columns. I've added vstack en route to bind_rows and bind_cols as a way of combining after split and apply. I've added a few helpers and enabled negative indexing on series. I've also added `drop_nil`.